### PR TITLE
adding execution_path attribute to helpers' reservation context

### DIFF
--- a/template/python/api/cloudshell_dev_helpers.py
+++ b/template/python/api/cloudshell_dev_helpers.py
@@ -9,6 +9,7 @@ CONNECTIVITY_DETAILS_TEMPLATE = '"tsAPIPort": "{cloudshell_api_port}",'\
 	'"{server_address}"'
 
 RESERVATIONDETAILS_TEMPLATE = '"environmentName":"{environment_name}",'\
+    '"environmentPath":"{environment_path}",'\
 	'"domain":"{domain}", "description":'\
 	'"{description}","parameters":{parameters_template},"ownerUser":'\
 	'"{owner_user}","ownerPass":"{owner_pass}","id":"{id}"'
@@ -129,7 +130,7 @@ def _bootstrap_data(user, password, domain, reservation_id,
         reservation_details = RESERVATIONDETAILS_TEMPLATE.\
             format(id=reservation_id, domain='Global',
                    description='', environment_name='',
-                   parameters_template='[]',
+                   environment_path='', parameters_template='[]',
                    owner_user=user, owner_pass=password)
 
         os.environ['qualiConnectivityContext'] = '{' + quali_connectivity + '}'
@@ -145,6 +146,7 @@ def _bootstrap_data(user, password, domain, reservation_id,
             format(id=reservation_id, domain=reservation_desc.DomainName,
                    description=reservation_desc.Description,
                    parameters_template='{' + parameters_details + '}',
+                   environmment_path=reservation_desc.Name,
                    environment_name=reservation_desc.Name,
                    owner_user=user, owner_pass=password)
 

--- a/template/python/api/cloudshell_scripts_helpers.py
+++ b/template/python/api/cloudshell_scripts_helpers.py
@@ -60,7 +60,8 @@ def get_reservation_context_details():
                                             env_params,
                                             res_dict['ownerUser'],
                                             res_dict['ownerPass'],
-                                            res_dict['id'])
+                                            res_dict['id'],
+                                            res_dict['environmentPath'])
     return res_details
 
 
@@ -195,7 +196,8 @@ class ResourceContextDetails:
 
 class ReservationContextDetails:
     def __init__(self, environment_name, domain, description,
-                 parameters, owner_user, owner_password, reservation_id):
+                 parameters, owner_user, owner_password,
+                 reservation_id, environment_path):
         self.environment_name = environment_name
         """:type : str"""
         self.domain = domain
@@ -209,6 +211,8 @@ class ReservationContextDetails:
         self.owner_password = owner_password
         """:type : str"""
         self.id = reservation_id
+        """:type : str"""
+        self.environment_path = environment_path
         """:type : str"""
 
 


### PR DESCRIPTION
Description:
adding execution_path attribute to helpers' reservation context to match with the changes occurred on the server.

Related Stories:
[Internal tfs story](http://team:8080/tfs/Quali-Collection/QualiSystems/_workitems?id=159231&_a=edit)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qualisystems/cloudshell-automation-api-generator/3)
<!-- Reviewable:end -->
